### PR TITLE
Add interactive dashboard stats card for active tabs

### DIFF
--- a/src/tabs/tabs.controller.ts
+++ b/src/tabs/tabs.controller.ts
@@ -94,6 +94,12 @@ export class TabsController {
     return this.tabsService.closeTab(id);
   }
 
+  @Get('active-members')
+  async getActiveMembersWithTabs() {
+    this.logger.log('Getting members with active tabs');
+    return this.tabsService.getActiveMembersWithTabs();
+  }
+
   @Get()
   async getTabs(
     @Query('status') status?: string,

--- a/src/tabs/tabs.service.ts
+++ b/src/tabs/tabs.service.ts
@@ -324,6 +324,28 @@ export class TabsService {
   }
 
   /**
+   * Get members with active tabs including tab summary information
+   */
+  async getActiveMembersWithTabs() {
+    this.logger.log('Fetching members with active tabs');
+
+    const activeTabs = await this.tabModel
+      .find({ status: 'active' })
+      .sort({ createdAt: -1 })
+      .exec();
+
+    return activeTabs.map(tab => ({
+      memberId: tab.memberId,
+      memberAccount: tab.memberAccount,
+      pcName: tab.pcName,
+      totalAmount: tab.totalAmount,
+      itemCount: tab.items.length,
+      createdAt: tab.createdAt,
+      tabId: tab._id.toString(),
+    }));
+  }
+
+  /**
    * Check if a member has an active tab
    */
   async hasActiveTab(memberId: number): Promise<boolean> {


### PR DESCRIPTION
- Add GET /tabs/active-members endpoint to fetch members with active tabs
- Include tab summary information (totalAmount, itemCount, pcName, tabId)
- Enable dashboard stats card to show actionable business data